### PR TITLE
Add joy_combo.py for combo inputs

### DIFF
--- a/config/joy_combo_example.yaml
+++ b/config/joy_combo_example.yaml
@@ -1,0 +1,16 @@
+timeout:
+  key: 0.05
+  combo: 0.3
+combos:
+  - combo: ['0']
+    print: '0'
+  - combo: ['0', '1']
+    print: '0 -> 1'
+  - combo: ['0:d', '1:d', '0:u', '1:u']
+    print: '0 (press) -> 1 (press) -> 0 (release) -> 1 (release)'
+  - combo: ['0:d', '1', '0:u']
+    print: '0 (press) -> 1 -> 0 (release)'
+  - combo: [['0:d', '1:d'], ['0:u', '1:u']]
+    print: '(0, 1)'
+  - combo: [['0', '1'], ['0', '1']]
+    print: '(0, 1) -> (0, 1)'

--- a/launch/joy_combo_example.launch
+++ b/launch/joy_combo_example.launch
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<launch>
+  <node pkg="joy_utils" type="joy_combo.py" name="joy_combo" output="screen" >
+    <rosparam command="load" file="$(find joy_utils)/config/joy_combo_example.yaml" />
+  </node>
+</launch>

--- a/nodes/joy_combo.py
+++ b/nodes/joy_combo.py
@@ -6,9 +6,17 @@ from joy_utils.combo import Combo
 
 
 def cb_timer(combo_manager, combo_dict):
-    # Type of c.triggered_combo: tuple[frozenset[str]]
-    if combo_manager.triggered_combo is not None:
-        rospy.loginfo(combo_dict[combo_manager.triggered_combo])
+    # Type of triggered: tuple[frozenset[str]]
+    triggered = combo_manager.triggered_combo
+    if triggered is not None:
+        if triggered in combo_dict:
+            rospy.loginfo(combo_dict[triggered])
+        else:
+            buttons = []
+            for key in triggered:
+                fmt = '({})' if len(key) > 1 else '{}'
+                buttons.append(fmt.format(', '.join(sorted(key))))
+            rospy.loginfo(', '.join(buttons))
         combo_manager.clear()
 
 

--- a/nodes/joy_combo.py
+++ b/nodes/joy_combo.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+import rospy
+from sensor_msgs.msg import Joy
+from joy_utils.combo import Combo
+
+
+def cb_timer(combo_manager, combo_dict):
+    # Type of c.triggered_combo: tuple[frozenset[str]]
+    if combo_manager.triggered_combo is not None:
+        rospy.loginfo(combo_dict[combo_manager.triggered_combo])
+        combo_manager.clear()
+
+
+def main():
+    rospy.init_node('joy_combo')
+
+    timeout_key = rospy.get_param('~timeout/key', 0.05)
+    timeout_combo = rospy.get_param('~timeout/combo', 0.3)
+
+    combo_dict = {}
+    for definition in rospy.get_param('~combos'):
+        combo = definition['combo']
+        to_print = definition['print']
+
+        dict_key = Combo.make_combo(combo)
+        combo_dict[dict_key] = to_print
+
+    c = Combo(combo_dict.keys(),
+              timeout_key=timeout_key,
+              timeout_combo=timeout_combo)
+    cb_timer.combo_handler = c
+
+    rospy.Subscriber('joy', Joy, c.process, queue_size=1)
+    rospy.Timer(rospy.Duration.from_sec(0.1), lambda _: cb_timer(c, combo_dict))
+
+    rospy.spin()
+
+
+if __name__ == '__main__':
+    main()

--- a/nodes/joy_conv.py
+++ b/nodes/joy_conv.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 
-from joy_utils.converter import Converter
-
 import rospy
 from sensor_msgs.msg import Joy
+from joy_utils.converter import Converter
 
 
 class JoyConv(object):

--- a/src/joy_utils/combo.py
+++ b/src/joy_utils/combo.py
@@ -7,7 +7,7 @@ import six
 
 class Combo(object):
     def __init__(self,
-                 combos,
+                 combos=None,
                  timeout_key=0.05,
                  timeout_combo=0.3,
                  data_to_dict=None):
@@ -123,7 +123,7 @@ class Combo(object):
         combo = self._squash_combo_(self._current_combo)
 
         # print('Combo {}'.format(combo))
-        if combo in self._combo_definitions:
+        if self._combo_definitions is None or combo in self._combo_definitions:
             self.triggered_combo = copy.deepcopy(combo)
         else:
             self.clear()

--- a/src/joy_utils/combo.py
+++ b/src/joy_utils/combo.py
@@ -208,6 +208,11 @@ class Combo(object):
         :type joy_msg: Joy
         :return dict of button indices (in string) and values
         """
+        if not isinstance(joy_msg, Joy):
+            name = joy_msg.__class__.__name__
+            fmt = 'Expected Joy instance but got {} instead'
+            rospy.logwarn_throttle(5, fmt.format(name))
+
         msg_dict = {}
         for i, value in enumerate(joy_msg.buttons):
             msg_dict[str(i)] = value

--- a/src/joy_utils/combo.py
+++ b/src/joy_utils/combo.py
@@ -1,0 +1,236 @@
+import rospy
+from sensor_msgs.msg import Joy
+
+import copy
+import six
+
+
+class Combo(object):
+    def __init__(self,
+                 combos,
+                 timeout_key=0.05,
+                 timeout_combo=0.3,
+                 data_to_dict=None):
+        """
+        Terminology:
+          Key: one button press or a group of buttons pressed simultaneously
+          Combo: sequence of keys
+
+        :param combos: all available combos
+        :type combos: collections.Iterable[tuple[frozenset[str]]]
+        :param timeout_key: timeout to consider button presses simultaneous
+        :param timeout_combo: timeout to consider combo input to be completed
+        :param data_to_dict: method to convert arbitrary data to dict
+        """
+        self._combo_definitions = combos
+        self._timeout_key = timeout_key
+        self._timeout_combo = timeout_combo
+        # Method to convert arbitrary data to dict[button_name, value]
+        if data_to_dict is None:
+            self._data_to_dict = self._joy_msg_to_dict_
+        else:
+            self._data_to_dict = data_to_dict
+
+        self._prev_high_buttons = set()
+
+        # Contains the triggered combo
+        self.triggered_combo = None
+        self._current_key = set()
+        self._current_combo = []
+
+        self._timer_key = None
+        self._timer_combo = None
+
+    def process(self, data):
+        """
+        Processes the input data and update combo
+        Note that a combo is not completed during this method call because we
+        need to wait for the combo timeout after the last key was pressed
+        (i.e. this method was called). Check whether the value of
+        Combo.triggered_combo is None.
+        :return: name of buttons that are high, released, and pressed
+        :rtype: tuple[set[str], set[str], set[str]]
+        """
+        high_buttons = self._get_high_buttons_(data)
+
+        up = self._prev_high_buttons - high_buttons
+        down = high_buttons - self._prev_high_buttons
+
+        self._add_to_key_(up, down)
+
+        self._prev_high_buttons = high_buttons
+
+        return high_buttons, up, down
+
+    def ongoing_combo(self):
+        return copy.deepcopy(self._current_combo)
+
+    def clear(self):
+        self.triggered_combo = None
+        self._current_key.clear()
+        self._current_combo = []
+
+    def _get_high_buttons_(self, data):
+        """
+        Creates a set of buttons that have high values (i.e. 1)
+        :param data: dict of button name and value
+        :return: name of the buttons that are high
+        :rtype: set[str]
+        """
+        if isinstance(data, dict):
+            msg_dict = data
+        else:
+            msg_dict = self._data_to_dict(data)
+
+        high_buttons = set()
+        for button_name, value in msg_dict.items():
+            if value:
+                high_buttons.add(str(button_name))
+        return high_buttons
+
+    def _add_to_key_(self, up, down):
+        # No key was pressed or released
+        if len(up.union(down)) == 0:
+            return
+
+        for button in up:
+            self._current_key.add(button + ':u')
+        for button in down:
+            self._current_key.add(button + ':d')
+
+        if self._timer_key is not None:
+            self._timer_key.shutdown()
+        self._timer_key = rospy.Timer(
+            rospy.Duration.from_sec(self._timeout_key),
+            self._add_to_combo_,
+            oneshot=True,
+        )
+
+    def _add_to_combo_(self, _):
+        # print('Pressed: {}'.format(self._current_key))
+        self._current_combo.append(frozenset(self._current_key))
+        self._current_key.clear()
+
+        if self._timer_combo is not None:
+            self._timer_combo.shutdown()
+        self._timer_combo = rospy.Timer(
+            rospy.Duration.from_sec(self._timeout_combo),
+            self._set_combo_,
+            oneshot=True,
+        )
+
+    def _set_combo_(self, _):
+        combo = self._squash_combo_(self._current_combo)
+
+        # print('Combo {}'.format(combo))
+        if combo in self._combo_definitions:
+            self.triggered_combo = copy.deepcopy(combo)
+        else:
+            self.clear()
+
+    @staticmethod
+    def _squash_combo_(combo):
+        """
+        Squash consecutive press/release of the same key into one key
+        For example, squashing [button1:d, button2:d, button2:u, button1:u] becomes
+        [button1:d, button2, button1:u].
+        :param combo:
+        :type combo: collections.Sequence[collections.Set[str]]
+        :return:
+        """
+        squashed_combo = []
+
+        last_key_was_squashed = False
+        # Squash back-to-back press/release
+        for i, key_set in enumerate(combo[:-1]):
+            next_key_set = combo[i + 1]
+
+            # If last key was squashed, we need to skip over this key because
+            # it is already squashed into the previous key
+            if last_key_was_squashed:
+                last_key_was_squashed = False
+                continue
+
+            # Only squash key that was pressed and then released
+            all_down = all([button.endswith(':d') for button in key_set])
+            all_up = all([button.endswith(':u') for button in next_key_set])
+            if not all_down or not all_up:
+                squashed_combo.append(Combo._squash_key_(key_set))
+                continue
+
+            buttons = set([b.rsplit(':', 1)[0] for b in key_set])
+            next_buttons = set([b.rsplit(':', 1)[0] for b in next_key_set])
+
+            # Back-to-back press/release
+            last_key_was_squashed = buttons == next_buttons
+            if last_key_was_squashed:
+                squashed_combo.append(frozenset(buttons))
+            # Squash key like (3:u, 3:d) to (3)
+            # but leave key like (3:u, circle:u) as is
+            else:
+                squashed_combo.append(Combo._squash_key_(key_set))
+
+        if not last_key_was_squashed:
+            squashed_combo.append(Combo._squash_key_(combo[-1]))
+
+        return tuple(squashed_combo)
+
+    @staticmethod
+    def _squash_key_(key):
+        """
+        :param key:
+        :type key: collections.Set[str]
+        :return:
+        """
+        combined = set()
+        for button_with_suffix in key:
+            split_tokens = button_with_suffix.rsplit(':', 1)
+            # No colon was found (i.e. no suffix was present)
+            if len(split_tokens) == 1:
+                combined.add(button_with_suffix)
+                continue
+
+            button, suffix = split_tokens
+            opposite_suffix = 'd' if suffix == 'u' else 'u'
+
+            # If both up and down are in the same key, use name of button
+            if button + ':' + opposite_suffix in key:
+                combined.add(button)
+            # Otherwise, append suffix (:u or :d) to indicate up/down
+            else:
+                combined.add(button_with_suffix)
+        return frozenset(combined)
+
+    @staticmethod
+    def _joy_msg_to_dict_(joy_msg):
+        """
+        Converts a sensor_msgs/Joy message to dict
+        :type joy_msg: Joy
+        :return dict of button indices (in string) and values
+        """
+        msg_dict = {}
+        for i, value in enumerate(joy_msg.buttons):
+            msg_dict[str(i)] = value
+        return msg_dict
+
+    @staticmethod
+    def make_combo(*args):
+        """
+        Creates a combo with the correct type
+        :param args:
+        :return:
+        """
+        if len(args) == 0:
+            raise ValueError('At least one argument must be passed')
+        elif isinstance(args[0], six.string_types):
+            combo = [args[0]]
+        elif len(args) == 1:
+            combo = args[0]
+        else:
+            combo = args
+        ret = []
+        for key in combo:
+            if isinstance(key, six.string_types):
+                key = [key]
+            ret.append(frozenset(key))
+        return Combo._squash_combo_(ret)

--- a/tests/test_combo.py
+++ b/tests/test_combo.py
@@ -1,0 +1,58 @@
+from joy_utils.combo import Combo
+
+
+class TestCombo(object):
+    # noinspection PyAttributeOutsideInit
+    def setup_method(self):
+        fs = frozenset
+        # Description
+        #   - String representation
+        #   - String interpreted to combo
+        #   - Combo squashed
+        self.combo_definitions = [
+            # Single button press/release (denoted as P/R)
+            (
+                ['b0:d', 'b0:u'],
+                (fs(['b0:d']), fs(['b0:u'])),
+                (fs(['b0']),),
+            ),
+
+            # b0 P/R -> b1 P/R
+            (
+                ['b0', 'b1:d', 'b1:u'],
+                (fs(['b0:d']), fs(['b0:u']), fs(['b1:d']), fs(['b1:u'])),
+                (fs(['b0']), fs(['b1'])),
+            ),
+
+            # b0 press -> b1 press -> b0 release -> b1 release
+            (
+                ['b0:d', 'b1:d', 'b0:u', 'b1:u'],
+                (fs(['b0:d']), fs(['b1:d']), fs(['b0:u']), fs(['b1:u'])),
+                (fs(['b0:d']), fs(['b1:d']), fs(['b0:u']), fs(['b1:u'])),
+            ),
+
+            # b0 press -> b1 P/R -> b0 release
+            (
+                ['b0:d', 'b1', 'b0:u'],
+                (fs(['b0:d']), fs(['b1:d']), fs(['b1:u']), fs(['b0:u'])),
+                (fs(['b0:d']), fs(['b1']), fs(['b0:u'])),
+            ),
+        ]
+
+    def test_make_combo(self):
+        for string, _, squashed in self.combo_definitions:
+            assert Combo.make_combo(string) == squashed
+        # More cases
+        assert Combo.make_combo('b0') == (frozenset(['b0']),)
+
+    def test_squash_key(self):
+        k1 = {'b0:d', 'b0:u'}
+        assert Combo._squash_key_(k1) == {'b0'}
+        k2 = {'b0'}
+        assert Combo._squash_key_(k2) == {'b0'}
+        k3 = {'b0:d', 'b0:u', 'b1:d', 'b1:u'}
+        assert Combo._squash_key_(k3) == {'b0', 'b1'}
+
+    def test_squash_combo(self):
+        for _, orig_combo, squashed_combo in self.combo_definitions:
+            assert Combo._squash_combo_(orig_combo) == squashed_combo


### PR DESCRIPTION
This PR enables easy processing of combo inputs. A combo input is a sequence of button presses, such as [<kbd>↑</kbd><kbd>↑</kbd><kbd>↓</kbd><kbd>↓</kbd><kbd>→</kbd><kbd>←</kbd><kbd>→</kbd><kbd>←</kbd><kbd>B</kbd><kbd>A</kbd>](https://en.wikipedia.org/wiki/Konami_Code).

This PR adds the `Combo` module, which can be used to feed in arbitrary data and produce a combo from it.

To run the sample, execute:

```
$ roslaunch joy_utils joy_combo_example.launch
```

On your joypad, press and release the `button[0]` (normally one of the four buttons on the right). You should see:

```
[INFO] [/joy_combo] [1573824203.560322]: 0
```

Now, press/release `button[0]` and then `button[1]`.

```
[INFO] [/joy_combo] [1573824205.760233]: 0 -> 1
```

`button[0]` and `button[1]` at the same time.

```
[INFO] [/joy_combo] [1573824210.960309]: (0, 1)
```

Simultaneously press/release `button[0]` and `button[1]` twice in a row.

```
[INFO] [/joy_combo] [1573824212.460107]: (0, 1) -> (0, 1)
```

Press `button[0]`, then press/release `button[1]` while holding `button[0]`, then release `button[0]`.

```
[INFO] [/joy_combo] [1573824217.959858]: 0 (press) -> 1 -> 0 (release)
```

Press `button[0]`, then `button[1]`, then release `button[0]`, and finally release `button[1]`.

```
[INFO] [/joy_combo] [1573824222.860437]: 0 (press) -> 1 (press) -> 0 (release) -> 1 (release)
```